### PR TITLE
add more spacing to generation debug

### DIFF
--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -139,8 +139,10 @@ impl Builder {
         }
 
         // generate the site
+        println!("\ngenerating site:");
         for layer in &layers {
             for node in layer {
+                println!("generating {}", node);
                 node.resource().borrow_mut().generate()?;
             }
         }


### PR DESCRIPTION
This PR adds a little extra spacing in the generation phase debug statements.